### PR TITLE
changing label settings

### DIFF
--- a/Nextflow/conf/base.config
+++ b/Nextflow/conf/base.config
@@ -10,38 +10,34 @@
  */
 
 process {
-       cpus = { check_max( 4, 'cpus' ) }
-       memory = { check_max( 25.GB, 'memory' ) }
-       time = { check_max( 240.h, 'time' ) }
-
        withLabel:process_very_low {
-              cpus = { check_max( 2 * task.attempt, 'cpus' ) }
-              memory = { check_max( 4.GB * task.attempt, 'memory' ) }
-              time = { check_max( 3.h * task.attempt, 'time' ) }
+              cpus = { 2 * task.attempt }
+              memory = { 4.GB * task.attempt }
+              time = { 3.h * task.attempt }
        }
        withLabel:process_low {
-              cpus = { check_max( 4 * task.attempt, 'cpus' ) }
-              memory = { check_max( 8.GB * task.attempt, 'memory' ) }
-              time = { check_max( 6.h * task.attempt, 'time' ) }
+              cpus = { 4 * task.attempt }
+              memory = { 8.GB * task.attempt }
+              time = { 6.h * task.attempt }
        }
        withLabel:process_medium {
-              cpus = { check_max( 8 * task.attempt, 'cpus' ) }
-              memory = { check_max( 16.GB * task.attempt, 'memory' ) }
-              time = { check_max( 8.h * task.attempt, 'time' ) }
+              cpus = { 8 * task.attempt }
+              memory = { 16.GB * task.attempt }
+              time = { 8.h * task.attempt }
        }
        withLabel:process_high {
-              cpus = { check_max( 16 * task.attempt, 'cpus' ) }
-              memory = { check_max( 32.GB * task.attempt, 'memory' ) }
-              time = { check_max( 10.h * task.attempt, 'time' ) }
+              cpus = { 16 * task.attempt }
+              memory = { 32.GB * task.attempt }
+              time = { 10.h * task.attempt }
        }
        withLabel:process_long {
-              time = { check_max( 20.h * task.attempt, 'time' ) }
+              time = { 20.h * task.attempt }
        }
        withLabel:process_single_thread {
-              cpus = { check_max( 1 * task.attempt, 'cpus' ) }
+              cpus = { 1 }
        }
        withLabel:process_dual_threads {
-              cpus = { check_max( 2 * task.attempt, 'cpus' ) }
+              cpus = { 2  }
        }
 }
 


### PR DESCRIPTION
This PR fixes the problem with the non-parallel execution of thermo2mzdb.
Though I am not completely sure, whether it creates any other problems with too low/high provision of resources.

Actually, this could also be changed in all other wombat-p workflows, if it runs.